### PR TITLE
Class object `verbose` is not created if verbose variable is not set to true on initialization.

### DIFF
--- a/LiveCryptoData.py
+++ b/LiveCryptoData.py
@@ -30,8 +30,8 @@ class LiveCryptoData(object):
     if isinstance(ticker, str) is False:
       raise TypeError("The 'ticker' argument must be a string object.")
 
+    self.verbose = verbose
     if verbose:
-      self.verbose = verbose
       self.pbar = pbar
     self.ticker = ticker
 


### PR DESCRIPTION
If you call `LiveCryptoData("BTC-USD", True).return_data()` everything works fine, but if verbose is disabled on initialization you will hit an error in `return_data()` since it checks for `self.verbose` which hasn't yet been defined. That means `LiveCryptoData("BTC-USD", False).return_data()` returns `AttributeError: 'LiveCryptoData' object has no attribute 'verbose'`.