### PR TITLE
change append to _append DataFrame method

### DIFF
--- a/HistoricalData.py
+++ b/HistoricalData.py
@@ -173,7 +173,7 @@ class HistoricalData(object):
                                                                          (int(request_volume / max_per_mssg) + 1)))
                     dataset = pd.DataFrame(json.loads(response.text))
                     if not dataset.empty:
-                        data = data.append(dataset)
+                        data = data._append(dataset)
                         time.sleep(randint(0, 2))
                     else:
                         print("""CoinBase Pro API did not have available data for '{}' beginning at {}.  


### PR DESCRIPTION
According to the update of the pandas library, the DataFrame object no longer has a method 'append', for backward compatibility, you should use the '_append' method